### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-area120-tables",
     "distribution_name": "google-area120-tables",
     "api_id": "area120tables.googleapis.com",
-    "default_version": "",
+    "default_version": "v1alpha1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,15 @@
 {
-  "name": "area120tables",
-  "name_pretty": "Area 120 Tables API",
-  "product_documentation": "",
-  "client_documentation": "https://googleapis.dev/python/area120tables/latest",
-  "issue_tracker": "",
-  "release_level": "alpha",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-area120-tables",
-  "distribution_name": "google-area120-tables",
-  "api_id": "area120tables.googleapis.com"
+    "name": "area120tables",
+    "name_pretty": "Area 120 Tables API",
+    "product_documentation": "",
+    "client_documentation": "https://googleapis.dev/python/area120tables/latest",
+    "issue_tracker": "",
+    "release_level": "alpha",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-area120-tables",
+    "distribution_name": "google-area120-tables",
+    "api_id": "area120tables.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs:

googleapis/synthtool#1201
googleapis/synthtool#1114